### PR TITLE
Add form control class to all fields in TuneForm

### DIFF
--- a/tune/forms.py
+++ b/tune/forms.py
@@ -21,6 +21,11 @@ class TuneForm(ModelForm):
             "year",
             "tags",
         ]
+    
+    def __init__(self, *args, **kwargs):
+        super(TuneForm, self).__init__(*args, **kwargs)
+        for field in self.fields:
+            self.fields[field].widget.attrs["class"] = "form-control"
 
     def clean_key(self):
         """


### PR DESCRIPTION
Hi Jeff, I wanted to show you here how you can further use the form class to tell the front end how to render the class by passing attrs.

What's happening here is that HTML for each field get's rendered with the form-control class.

> Give textual form controls like \<input>s and <textarea>s an upgrade with custom styles, sizing, focus states, and more.

https://getbootstrap.com/docs/5.0/forms/form-control/